### PR TITLE
Set optimization level

### DIFF
--- a/src/utils/optimize.ts
+++ b/src/utils/optimize.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process"
 export default (filepath: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     console.log(`optimizing ${filepath}`)
-    const opti = spawn("optipng", [filepath])
+    const opti = spawn("optipng", ["-o2", filepath])
 
     opti.on("error", (err) => {
       console.error(err)


### PR DESCRIPTION
- Fixes #29 
- Optimization level is set to `-o2`, which should be fast enough & creates small enough files for our purpose.